### PR TITLE
Add type hints and docstrings so funcs work with tool calling

### DIFF
--- a/nbs/00_read.ipynb
+++ b/nbs/00_read.ipynb
@@ -67,7 +67,9 @@
     "from toolslm.download import html2md, read_html\n",
     "\n",
     "import tempfile, subprocess, os, re, shutil\n",
-    "from pathlib import Path"
+    "from pathlib import Path\n",
+    "\n",
+    "from typing import Optional, List, Dict, Union"
    ]
   },
   {
@@ -94,18 +96,18 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_url(url,           # URL to read\n",
-    "             heavy=False,   # Use headless browser\n",
-    "             sel=None,      # Css selector to pull content from\n",
-    "             useJina=False, # Use Jina for the markdown conversion\n",
-    "             ignore_links=False, # Whether to keep links or not\n",
-    "             **kwargs): \n",
+    "def read_url(url: str,           # URL to read\n",
+    "             heavy: bool = False,   # Use headless browser\n",
+    "             sel: Optional[str] = None,      # Css selector to pull content from\n",
+    "             useJina: bool = False, # Use Jina for the markdown conversion\n",
+    "             ignore_links: bool = False, # Whether to keep links or not\n",
+    "             ): \n",
     "    \"Reads a url and converts to markdown\"\n",
-    "    if not heavy and not useJina: return read_html(url,sel=sel, ignore_links=ignore_links, **kwargs)\n",
+    "    if not heavy and not useJina: return read_html(url,sel=sel, ignore_links=ignore_links)\n",
     "    elif not heavy and useJina:   return httpx.get(f\"https://r.jina.ai/{url}\").text\n",
     "    elif heavy and not useJina: \n",
     "        import playwrightnb\n",
-    "        return playwrightnb.url2md(url,sel=ifnone(sel,'body'), **kwargs)\n",
+    "        return playwrightnb.url2md(url,sel=ifnone(sel,'body'))\n",
     "    elif heavy and useJina: raise NotImplementedError(\"Unsupported. No benefit to using Jina with playwrightnb\")\n"
    ]
   },
@@ -197,7 +199,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_gist(url):\n",
+    "def read_gist(url:str):\n",
     "    \"Returns raw gist content, or None\"\n",
     "    pattern = r'https://gist\\.github\\.com/([^/]+)/([^/]+)'\n",
     "    match = re.match(pattern, url)\n",
@@ -255,7 +257,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_gh_file(url):\n",
+    "def read_gh_file(url:str):\n",
     "    \"Reads the contents of a file from its GitHub URL\"\n",
     "    pattern = r'https://github\\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)'\n",
     "    replacement = r'https://raw.githubusercontent.com/\\1/\\2/refs/heads/\\3/\\4'\n",
@@ -308,7 +310,9 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_file(path): return open(path,'r').read()"
+    "def read_file(path:str):\n",
+    "    \"returns file contents\"\n",
+    "    return open(path,'r').read()"
    ]
   },
   {
@@ -319,7 +323,7 @@
    "outputs": [],
    "source": [
     "#|export\n",
-    "def is_unicode(filepath, sample_size=1024):\n",
+    "def is_unicode(filepath:str, sample_size:int=1024):\n",
     "    try:\n",
     "        with open(filepath, 'r') as file: sample = file.read(sample_size)\n",
     "        return True\n",
@@ -353,13 +357,14 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_dir(path,                          # path to read\n",
-    "             unicode_only=True,             # ignore non-unicode files\n",
-    "             included_patterns=[\"*\"],       # glob pattern of files to include\n",
-    "             excluded_patterns=[\".git/**\"], # glob pattern of files to exclude\n",
-    "             verbose=True,                  # log paths of files being read\n",
-    "             as_dict=False                  # returns dict of {path,content}\n",
-    "            ) -> str|dict:                  # returns string with contents of files read\n",
+    "def read_dir(path: str,                          # path to read\n",
+    "             unicode_only: bool = True,             # ignore non-unicode files\n",
+    "             included_patterns: List[str] = [\"*\"],       # glob pattern of files to include\n",
+    "             excluded_patterns: List[str] = [\".git/**\"], # glob pattern of files to exclude\n",
+    "             verbose: bool = True,                # log paths of files being read\n",
+    "             as_dict: bool = False                  # returns dict of {path,content}\n",
+    "            ) -> Union[str, Dict[str, str]]:            # returns string with contents of files read\n",
+    "    \"\"\"Reads files in path, returning a dict with the filenames and contents if as_dict=True, otherwise concatenating file contents into a single string. Takes optional glob patterns for files to include or exclude.\"\"\"\n",
     "    pattern = '**/*'\n",
     "    result = {}\n",
     "    for file_path in glob.glob(os.path.join(path, pattern), recursive=True):\n",
@@ -418,6 +423,7 @@
    "source": [
     "#| export\n",
     "def read_pdf(file_path: str) -> str:\n",
+    "    \"Reads the text of a PDF with PdfReader\"\n",
     "    with open(file_path, 'rb') as file:\n",
     "        reader = PdfReader(file)\n",
     "        return ' '.join(page.extract_text() for page in reader.pages)"
@@ -460,7 +466,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_yt_transcript(yt_url):\n",
+    "def read_yt_transcript(yt_url: str):\n",
+    "    \"Gets the text of a YouTube transcript\"\n",
     "    from pytube import YouTube\n",
     "    from youtube_transcript_api import YouTubeTranscriptApi\n",
     "    try:\n",
@@ -478,22 +485,12 @@
    "execution_count": null,
    "id": "bd719b5e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'- [Tim] A widescreen\\niPod with touch controls, a revolutionary mobile phone, and a breakthrough internet\\ncommunications device. (energetic music) (phone vibrating) Profound new intelligence capabiliti'"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "yt_url = \"https://youtu.be/MRtg6A1f2Ko?si=C7YZU6FFLdi6v9rk\"\n",
-    "s = read_yt_transcript(yt_url)\n",
-    "s[:200]"
+    "# yt_url = \"https://www.youtube.com/watch?v=BGgsoIgbT_Y\"\n",
+    "# s = read_yt_transcript(yt_url)\n",
+    "# s[:200]\n",
+    "# Currently seems broken, removing #| export "
    ]
   },
   {
@@ -512,7 +509,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_google_sheet(url):\n",
+    "def read_google_sheet(url: str):\n",
+    "    \"Reads the contents of a Google Sheet into text\"\n",
     "    sheet_id = url.split('/d/')[1].split('/')[0]\n",
     "    csv_url = f'https://docs.google.com/spreadsheets/d/{sheet_id}/export?format=csv&id={sheet_id}&gid=0'\n",
     "    res = requests.get(url=csv_url)\n",
@@ -555,7 +553,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def gdoc_url_to_parseable(url):\n",
+    "def gdoc_url_to_parseable(url: str):\n",
     "    pattern = r'(https://docs\\.google\\.com/document/d/[^/]+)/edit'\n",
     "    replacement = r'\\1/export?format=html'\n",
     "    return re.sub(pattern, replacement, url)"
@@ -589,7 +587,8 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_gdoc(url):\n",
+    "def read_gdoc(url: str):\n",
+    "    \"Gets the text content of a Google Doc using html2text\"\n",
     "    import html2text\n",
     "    doc_url = url\n",
     "    doc_id = doc_url.split('/d/')[1].split('/')[0]\n",
@@ -636,7 +635,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_arxiv(url, save_pdf=False, save_dir='.'):\n",
+    "def read_arxiv(url:str, save_pdf:bool=False, save_dir:str='.'):\n",
     "    \"Get paper information from arxiv URL or ID, optionally saving PDF to disk\"\n",
     "    import re, httpx, tarfile, io, os\n",
     "    import xml.etree.ElementTree as ET\n",
@@ -727,7 +726,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def _gh_ssh_from_gh_url(gh_repo_address):\n",
+    "def _gh_ssh_from_gh_url(gh_repo_address:str):\n",
     "    \"Given a GH URL or SSH remote address, returns a GH URL or None\"\n",
     "    pattern = r'https://github\\.com/([^/]+)/([^/]+)(?:/.*)?'\n",
     "    if gh_repo_address.startswith(\"git@github.com:\"):\n",
@@ -739,7 +738,7 @@
     "        # Not a GitHub URL or a GitHub SSH remote address\n",
     "        return None\n",
     "\n",
-    "def _get_default_branch(repo_path):\n",
+    "def _get_default_branch(repo_path:str):\n",
     "    \"master or main\"\n",
     "    try:\n",
     "        result = subprocess.run(['git', 'symbolic-ref', 'refs/remotes/origin/HEAD'], \n",
@@ -748,7 +747,7 @@
     "    except subprocess.CalledProcessError:\n",
     "        return 'main'  # Default to 'main' if we can't determine the branch\n",
     "\n",
-    "def _get_git_repo(gh_ssh):\n",
+    "def _get_git_repo(gh_ssh:str):\n",
     "    \"Fetchs from a GH SSH address, returns a path\"\n",
     "    repo_name = gh_ssh.split('/')[-1].replace('.git', '')\n",
     "    cache_dir = Path(os.environ.get('XDG_CACHE_HOME', Path.home() / '.cache')) / 'contextkit_git_clones'\n",
@@ -785,7 +784,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def read_gh_repo(path_or_url, as_dict=True, verbose=True):\n",
+    "def read_gh_repo(path_or_url:str, as_dict:bool=True, verbose:bool=True):\n",
     "    \"Repo contents from path, GH URL, or GH SSH address\"\n",
     "    gh_ssh = _gh_ssh_from_gh_url(path_or_url)\n",
     "    path = path_or_url if not gh_ssh else _get_git_repo(gh_ssh)\n",
@@ -821,38 +820,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/llms.txt\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/00_core.ipynb\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/_quarto.yml\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/LICENSE\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/styles.css\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/CHANGELOG.md\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/CNAME\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/pyproject.toml\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/02_async.ipynb\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/MANIFEST.in\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/apilist.txt\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/README.md\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/setup.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/nbdev.yml\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx.txt\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/README.txt\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/settings.ini\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/index.ipynb\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/claudette/toolloop.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/claudette/_modidx.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/claudette/__init__.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/claudette/core.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/claudette/asink.py\n",
-      "Including /Users/iflath/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh\n"
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/pyproject.toml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/LICENSE\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/CNAME\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms-ctx.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/apilist.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/_quarto.yml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/setup.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/README.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/03_text_editor.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/nbdev.yml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/02_async.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/index.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/styles.css\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/MANIFEST.in\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/settings.ini\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/CHANGELOG.md\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/README.md\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/00_core.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/core.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/text_editor.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/toolloop.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/asink.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/_modidx.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/__init__.py\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "dict_keys(['/Users/iflath/.cache/contextkit_git_clones/claudette/llms.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/00_core.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/_quarto.yml', '/Users/iflath/.cache/contextkit_git_clones/claudette/LICENSE', '/Users/iflath/.cache/contextkit_git_clones/claudette/styles.css', '/Users/iflath/.cache/contextkit_git_clones/claudette/CHANGELOG.md', '/Users/iflath/.cache/contextkit_git_clones/claudette/CNAME', '/Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/pyproject.toml', '/Users/iflath/.cache/contextkit_git_clones/claudette/02_async.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/MANIFEST.in', '/Users/iflath/.cache/contextkit_git_clones/claudette/apilist.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/README.md', '/Users/iflath/.cache/contextkit_git_clones/claudette/setup.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/nbdev.yml', '/Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/README.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/settings.ini', '/Users/iflath/.cache/contextkit_git_clones/claudette/index.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/toolloop.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/_modidx.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/__init__.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/core.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/asink.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh'])"
+       "dict_keys(['/home/johno/.cache/contextkit_git_clones/claudette/pyproject.toml', '/home/johno/.cache/contextkit_git_clones/claudette/LICENSE', '/home/johno/.cache/contextkit_git_clones/claudette/CNAME', '/home/johno/.cache/contextkit_git_clones/claudette/llms-ctx.txt', '/home/johno/.cache/contextkit_git_clones/claudette/apilist.txt', '/home/johno/.cache/contextkit_git_clones/claudette/_quarto.yml', '/home/johno/.cache/contextkit_git_clones/claudette/setup.py', '/home/johno/.cache/contextkit_git_clones/claudette/README.txt', '/home/johno/.cache/contextkit_git_clones/claudette/03_text_editor.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/nbdev.yml', '/home/johno/.cache/contextkit_git_clones/claudette/02_async.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/index.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt', '/home/johno/.cache/contextkit_git_clones/claudette/styles.css', '/home/johno/.cache/contextkit_git_clones/claudette/MANIFEST.in', '/home/johno/.cache/contextkit_git_clones/claudette/llms.txt', '/home/johno/.cache/contextkit_git_clones/claudette/settings.ini', '/home/johno/.cache/contextkit_git_clones/claudette/CHANGELOG.md', '/home/johno/.cache/contextkit_git_clones/claudette/README.md', '/home/johno/.cache/contextkit_git_clones/claudette/00_core.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/core.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/text_editor.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/toolloop.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/asink.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/_modidx.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/__init__.py'])"
       ]
      },
      "execution_count": null,
@@ -874,7 +875,7 @@
     {
      "data": {
       "text/plain": [
-       "\"# Claudette\\n\\n> Claudette is a Python library that wraps Anthropic's Claude API to provide a higher-level interface for creating AI applications. It automates common patterns while maintaining full control, offering features like stateful chat, prefill support, image handling, and streamlined tool use.\\n\\nThings to remember when using Claudette:\\n\\n- You must set the `ANTHROPIC_API_KEY` environment variable with your Anthropic API key\\n- Claudette is designed to work with Claude 3 models (Opus, Sonnet, Haiku) and supports multiple providers (Anthropic direct, AWS Bedrock, Google Vertex)\\n- The library provides both synchronous and asynchronous interfaces\\n- Use `Chat()` for maintaining conversation state and handling tool interactions\\n- When using tools, the library automatically handles the request/response loop\\n- Image support is built in but only available on compatible models (not Haiku)\\n\\n## Docs\\n\\n- [README](https://raw.githubusercontent.com/AnswerDotAI/claudette/refs/heads/main/README.md): Quick start guide and overview\\n\\n## API\\n\\n- [API List](https://raw.githubusercontent.com/AnswerDotAI/claudette/refs/heads/main/apilist.txt): A succint list of all functions and methods in claudette.\\n\\n## Optional\\n- [Tool loop handling](https://claudette.answer.ai/toolloop.html.md): How to use the tool loop functionality for complex multi-step interactions\\n- [Async support](https://claudette.answer.ai/async.html.md): Using Claudette with async/await\\n\""
+       "'[build-system]\\nrequires = [\"setuptools>=64.0\"]\\nbuild-backend = \"setuptools.build_meta\"\\n\\n[project]\\nname=\"claudette\"\\nrequires-python=\">=3.9\"\\ndynamic = [ \"keywords\", \"description\", \"version\", \"dependencies\", \"optional-dependencies\", \"readme\", \"license\", \"authors\", \"classifiers\", \"entry-points\", \"scripts\", \"urls\"]\\n\\n[tool.uv]\\ncache-keys = [{ file = \"pyproject.toml\" }, { file = \"settings.ini\" }, { file = \"setup.py\" }]\\n'"
       ]
      },
      "execution_count": null,
@@ -895,7 +896,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['/Users/iflath/.cache/contextkit_git_clones/claudette/llms.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/00_core.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/_quarto.yml', '/Users/iflath/.cache/contextkit_git_clones/claudette/LICENSE', '/Users/iflath/.cache/contextkit_git_clones/claudette/styles.css', '/Users/iflath/.cache/contextkit_git_clones/claudette/CHANGELOG.md', '/Users/iflath/.cache/contextkit_git_clones/claudette/CNAME', '/Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/pyproject.toml', '/Users/iflath/.cache/contextkit_git_clones/claudette/02_async.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/MANIFEST.in', '/Users/iflath/.cache/contextkit_git_clones/claudette/apilist.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/README.md', '/Users/iflath/.cache/contextkit_git_clones/claudette/setup.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/nbdev.yml', '/Users/iflath/.cache/contextkit_git_clones/claudette/llms-ctx.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/README.txt', '/Users/iflath/.cache/contextkit_git_clones/claudette/settings.ini', '/Users/iflath/.cache/contextkit_git_clones/claudette/index.ipynb', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/toolloop.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/_modidx.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/__init__.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/core.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/claudette/asink.py', '/Users/iflath/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh'])"
+       "dict_keys(['/home/johno/.cache/contextkit_git_clones/claudette/pyproject.toml', '/home/johno/.cache/contextkit_git_clones/claudette/LICENSE', '/home/johno/.cache/contextkit_git_clones/claudette/CNAME', '/home/johno/.cache/contextkit_git_clones/claudette/llms-ctx.txt', '/home/johno/.cache/contextkit_git_clones/claudette/apilist.txt', '/home/johno/.cache/contextkit_git_clones/claudette/_quarto.yml', '/home/johno/.cache/contextkit_git_clones/claudette/setup.py', '/home/johno/.cache/contextkit_git_clones/claudette/README.txt', '/home/johno/.cache/contextkit_git_clones/claudette/03_text_editor.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/nbdev.yml', '/home/johno/.cache/contextkit_git_clones/claudette/02_async.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/index.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt', '/home/johno/.cache/contextkit_git_clones/claudette/styles.css', '/home/johno/.cache/contextkit_git_clones/claudette/MANIFEST.in', '/home/johno/.cache/contextkit_git_clones/claudette/llms.txt', '/home/johno/.cache/contextkit_git_clones/claudette/settings.ini', '/home/johno/.cache/contextkit_git_clones/claudette/CHANGELOG.md', '/home/johno/.cache/contextkit_git_clones/claudette/README.md', '/home/johno/.cache/contextkit_git_clones/claudette/00_core.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb', '/home/johno/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/core.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/text_editor.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/toolloop.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/asink.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/_modidx.py', '/home/johno/.cache/contextkit_git_clones/claudette/claudette/__init__.py'])"
       ]
      },
      "execution_count": null,
@@ -913,7 +914,42 @@
    "execution_count": null,
    "id": "b347c101",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/pyproject.toml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/LICENSE\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/CNAME\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms-ctx.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/apilist.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/_quarto.yml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/setup.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/README.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/03_text_editor.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/nbdev.yml\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/02_async.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/index.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms-ctx-full.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/styles.css\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/MANIFEST.in\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/llms.txt\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/settings.ini\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/CHANGELOG.md\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/README.md\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/00_core.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/01_toolloop.ipynb\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/tools/refresh_llm_docs.sh\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/core.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/text_editor.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/toolloop.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/asink.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/_modidx.py\n",
+      "Including /home/johno/.cache/contextkit_git_clones/claudette/claudette/__init__.py\n"
+     ]
+    }
+   ],
    "source": [
     "#| hide\n",
     "s = read_gh_repo(ghurl)"


### PR DESCRIPTION
First pass at making CK compatible with tool calling. Only loss: read_url took kwargs to pass to read_html or playwright but I can't find a way to make `**kwargs` work with claudette's tool stuff. Not sure we used those options much but can make two versions of the function if needed?

![Screenshot 2025-06-10 102233](https://github.com/user-attachments/assets/2c38c6e3-305f-414d-a22c-b5e33bb97f13)
