### PR TITLE
Fixes read_arxiv to use HTTPS, and adds docments docs to various functions for tool support

### DIFF
--- a/contextkit/read.py
+++ b/contextkit/read.py
@@ -251,8 +251,8 @@ def _get_git_repo(gh_ssh:str):
 
 # %% ../nbs/00_read.ipynb 47
 def read_gh_repo(path_or_url:str,    # Repo's GitHub URL, or GH SSH address, or file path
-                 as_dict:bool=True, 
-                 verbose:bool=False
+                 as_dict:bool=True,  # if True, will return repo contents {path,content} dict
+                 verbose:bool=False  # if True, will log paths of files being read
                 ):
     "Repo contents from path, GH URL, or GH SSH address"
     gh_ssh = _gh_ssh_from_gh_url(path_or_url)

--- a/nbs/00_read.ipynb
+++ b/nbs/00_read.ipynb
@@ -804,8 +804,8 @@
    "source": [
     "#| export\n",
     "def read_gh_repo(path_or_url:str,    # Repo's GitHub URL, or GH SSH address, or file path\n",
-    "                 as_dict:bool=True, \n",
-    "                 verbose:bool=False\n",
+    "                 as_dict:bool=True,  # if True, will return repo contents {path,content} dict\n",
+    "                 verbose:bool=False  # if True, will log paths of files being read\n",
     "                ):\n",
     "    \"Repo contents from path, GH URL, or GH SSH address\"\n",
     "    gh_ssh = _gh_ssh_from_gh_url(path_or_url)\n",


### PR DESCRIPTION
- Arxiv.org started returning a 301 when you visit their HTTP URL. Commit fdfc490 fixes this library to use HTTPS, restoring lost functionality
- The other commits add docments-style comments to existing functions, so they can be used with SolveIt tool-calling if desired.
@johnowhitaker could you give this a quick look?